### PR TITLE
Multi-Day DataFrame Builder

### DIFF
--- a/guac/raw_data_builder.py
+++ b/guac/raw_data_builder.py
@@ -1,0 +1,110 @@
+import datetime
+import pandas as pd
+from loguru import logger
+
+from guac.google_reporting_api import GoogleReportingAPI
+
+def build_raw_data_df(report: dict) -> pd.DataFrame:
+    """
+    Builds a pandas DataFrame representing the raw data of
+    a Google Analytics Report.
+
+    The a Google Reporting Analytics API v4 Report is built for each
+    day between the provided start and end dates (inclusive). The reports
+    are compiled into a single pd.DataFrame and returned.
+
+    Parameters
+    ---
+    report: dict
+        A dictionary representing a Google Reporting Analytics API v4 Report object
+
+    Returns
+    ---
+    raw_data_df: pd.DataFrame
+        A DataFrame representing the raw data of a Google
+        Reporting Analytics API v4 Report.
+    """
+    logger.info(f'building raw data df for {report["viewId"]}...')
+    service = GoogleReportingAPI('GUAC_PIT', 'GOOGLE_REPORTING_API_SCOPES')
+
+    view_id = report['viewId']
+    report_dates = get_report_dates(report['dateRanges'][0])
+    dimensions = report['dimensions']
+    metrics = report['metrics']
+
+    reports = list()
+
+    for date in report_dates:
+        reports.append(service.get_report(
+            view_id=view_id,
+            start_date=date,
+            end_date=date,
+            dimensions=dimensions,
+            metrics=metrics
+            ))
+
+    return reports
+
+
+def get_report_dates(report_date_range: dict) -> list:
+    """
+    Extracts all the dates between a Reports date range (inclusive), returning
+    as a list.
+
+    Parameters
+    ---
+    report_date_range: dict
+        A dictionary representing a Reporting object's date range
+
+    Return
+    ---
+    report_dates: list
+        A list with each item as a string representation of a date
+        within the reports date range
+    """
+    report_dates = list()
+    start_date = report_date_range["startDate"]
+    end_date = report_date_range["endDate"]
+    logger.info(f'extracting dates betweeen {start_date} and {end_date}...')
+
+    report_dates.append(start_date)
+
+    pointer_date_string = start_date
+
+    while pointer_date_string != end_date:
+        pointer_dt = datetime.datetime.strptime(pointer_date_string, '%Y-%m-%d')
+        next_date = pointer_dt + datetime.timedelta(days=1)
+        pointer_date_string = next_date.strftime('%Y-%m-%d')
+        report_dates.append(pointer_date_string)
+
+    return report_dates
+
+def convert_report_to_df(report_response: object) -> pd.DataFrame:
+    """
+    Convert the Google Reporting API Report Response object
+    to a pd.DataFrame
+    """
+    logger.info('converting report to dataframe...')
+    column_header = report_response["columnHeader"]
+    column_header_dimensions = column_header['dimensions']
+    column_header_metric_header = column_header['metricHeader']
+    column_header_metric_header_entries = column_header_metric_header['metricHeaderEntries']
+    data = report_response["data"]
+    data_rows = data['rows']
+
+    # Build DataFrame
+    raw_df_headers = column_header_dimensions + \
+        [i['name'] for i in  column_header_metric_header_entries]
+    df_headers = [header.replace('ga:' , '').capitalize() for header in raw_df_headers]
+
+    df_rows = list()
+
+    for row in data_rows:
+        dimensions = row['dimensions']
+        for metrics in row['metrics']:
+            df_rows.append(dimensions + metrics['values'])
+    report_df = pd.DataFrame
+    df = pd.DataFrame(data=df_rows, columns=df_headers)
+    report_df = df
+
+    return report_df

--- a/guac/raw_data_builder.py
+++ b/guac/raw_data_builder.py
@@ -50,7 +50,7 @@ def build_raw_data_df(report: dict) -> pd.DataFrame:
 
         reports.append(report_df)
 
-    raw_data_df = pd.concat(reports)
+    raw_data_df = pd.concat(reports).reset_index(drop=True)
     logger.success(f'Raw data compiled: {raw_data_df.info()}')
     return raw_data_df
 

--- a/guac/raw_data_builder.py
+++ b/guac/raw_data_builder.py
@@ -43,7 +43,11 @@ def build_raw_data_df(report: dict) -> pd.DataFrame:
             metrics=metrics
             )
 
-        report_df = convert_report_to_df(report_response=report_response['reports'][0], report_date=date)
+        report_df = convert_report_to_df(
+            report_response=report_response['reports'][0],
+            report_date=date
+            )
+
         reports.append(report_df)
 
     raw_data_df = pd.concat(reports)
@@ -119,5 +123,5 @@ def convert_report_to_df(report_response: object, report_date: str) -> pd.DataFr
     ordered_headers = ['Date'] + df_headers
     report_df = df.loc[:, ordered_headers]
 
-    logger.success(f'{report_date} Report: {report_df.size()}')
+    logger.success(f'{report_date} Report: {str(report_df.size)}')
     return report_df

--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ import sys
 from dotenv import load_dotenv
 from loguru import logger
 
+from guac.google_reporting_api import GoogleReportingAPI
+from guac.raw_data_builder import build_raw_data_df
 
 # Logger and Environment Variables Configuration
 load_dotenv()
@@ -14,6 +16,33 @@ logger.add(sys.stderr,
 
 if __name__ == '__main__':
     logger.info(f'Running process on {__name__}.')
+    service = GoogleReportingAPI('GUAC_PIT', 'GOOGLE_REPORTING_API_SCOPES')
+
+    ALL_WEBSITE_SITE_DATA_VIEW_ID = '277792780'
+    START_DATE = '2022-10-10'
+    END_DATE = '2022-10-16'
+
+    dimensions = [
+        {'name': 'ga:country'},
+        {'name': 'ga:city'},
+        {'name': 'ga:browser'},
+        {'name': 'ga:operatingSystem'},
+        ]
+    metrics = [
+        {'expression': 'ga:sessions'},
+        {'expression': 'ga:users'},
+        {'expression': 'ga:pageviews'},
+        {'expression': 'ga:timeOnPage'},
+        ]
+
+    report_request = {
+            'viewId': ALL_WEBSITE_SITE_DATA_VIEW_ID,
+            'dateRanges': [{'startDate': START_DATE, 'endDate': END_DATE}],
+            'dimensions': dimensions,
+            'metrics': metrics
+            }
+    raw_data_df = build_raw_data_df(report=report_request)
+    logger.success(raw_data_df)
 
     logger.info('exiting main.')
     sys.exit(0)

--- a/tests/test_raw_data_builder/test_raw_data_builder.py
+++ b/tests/test_raw_data_builder/test_raw_data_builder.py
@@ -54,6 +54,6 @@ def test_convert_report_to_df():
 
     report_response = response['reports'][0]
 
-    report_df = convert_report_to_df(report_response)
+    report_df = convert_report_to_df(report_response=report_response, report_date=start_date)
 
     assert isinstance(report_df, pd.DataFrame)

--- a/tests/test_raw_data_builder/test_raw_data_builder.py
+++ b/tests/test_raw_data_builder/test_raw_data_builder.py
@@ -20,7 +20,7 @@ def test_build_raw_data_df():
         }
 
     raw_data_df = build_raw_data_df(report=report_request)
-    assert isinstance(raw_data_df[0], object)
+    assert isinstance(raw_data_df, pd.DataFrame)
     assert len(raw_data_df) > 1
 
 def test_get_report_dates():

--- a/tests/test_raw_data_builder/test_raw_data_builder.py
+++ b/tests/test_raw_data_builder/test_raw_data_builder.py
@@ -1,0 +1,59 @@
+import pandas as pd
+from guac.google_reporting_api import GoogleReportingAPI
+from guac.raw_data_builder import build_raw_data_df, get_report_dates, convert_report_to_df
+
+
+def test_build_raw_data_df():
+    """Test the 'build_raw_data_df' function of GUAC"""
+
+    all_web_site_data_view_id = '277792780'
+    start_date = '2022-10-10'
+    end_date = '2022-10-16'
+    dimensions = [{'name': 'ga:country'} ]
+    metrics = [{'expression': 'ga:sessions'}]
+
+    report_request = {
+        'viewId': all_web_site_data_view_id,
+        'dateRanges': [{'startDate': start_date, 'endDate': end_date}],
+        'dimensions': dimensions,
+        'metrics': metrics
+        }
+
+    raw_data_df = build_raw_data_df(report=report_request)
+    assert isinstance(raw_data_df[0], object)
+    assert len(raw_data_df) > 1
+
+def test_get_report_dates():
+    """Testing the 'get_report_dates' function of GUAC"""
+    date_range = {'startDate': '2022-10-01', 'endDate': '2022-10-16'}
+    dates = get_report_dates(date_range)
+
+    assert len(dates) == 16
+    assert dates[0] == '2022-10-01'
+    assert dates[1] == '2022-10-02'
+    assert dates[-2] == '2022-10-15'
+    assert dates[-1] == '2022-10-16'
+
+def test_convert_report_to_df():
+    """Test the 'convert_report_to_df' function of GUAC"""
+    service = GoogleReportingAPI('GUAC_PIT', 'GOOGLE_REPORTING_API_SCOPES')
+
+    all_web_site_data_view_id = '277792780'
+    start_date = '2022-10-10'
+    end_date = '2022-10-16'
+    dimensions = [{'name': 'ga:country'} ]
+    metrics = [{'expression': 'ga:sessions'}]
+
+    response = service.get_report(
+        view_id=all_web_site_data_view_id,
+        start_date=start_date,
+        end_date=end_date,
+        dimensions=dimensions,
+        metrics=metrics
+    )
+
+    report_response = response['reports'][0]
+
+    report_df = convert_report_to_df(report_response)
+
+    assert isinstance(report_df, pd.DataFrame)


### PR DESCRIPTION
The Google Analytics Reporting API v4 only allows for compiled data extracts, meaning data returned is sampled, aggregated, and fragmented from the raw data that exists for a UA property. GUAC can ingest a reporting in a standardized structure adhering to the API, however execute a `getBatch()` call for everyday in a reports date range, returning daily aggregation, compiled into a single pandas DataFrame. This mimics _raw data_ on a daily level of granularity/view.